### PR TITLE
Ignore catalog name when formatting table name for query

### DIFF
--- a/src/sql/sql_provider_datafusion/mod.rs
+++ b/src/sql/sql_provider_datafusion/mod.rs
@@ -319,12 +319,12 @@ impl<T, P> SqlExec<T, P> {
                 self.ident_escaped(&table)
             ),
             TableReference::Full {
-                catalog,
+                // if a full table reference is provided, we don't need to include the catalog
+                catalog: _,
                 schema,
                 table,
             } => format!(
-                "{}.{}.{}",
-                self.ident_escaped(&catalog),
+                "{}.{}",
                 self.ident_escaped(&schema),
                 self.ident_escaped(&table)
             ),


### PR DESCRIPTION
Strips the catalog name off the table reference when issuing the query. 